### PR TITLE
Fix attribution for RT#45160

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,7 +2,8 @@ Revision history for IO::CaptureOutput
 
 1.1102 Mon Feb 15 07:36:53 EST 2010
 
-    - Fixed test that confused archname and osname (reported by Tux)
+    - Fixed: RT#45160 test that confused archname and osname
+      (reported by Dolmen and Tux)
     
 1.1101 Tue Mar  3 23:30:45 EST 2009
 


### PR DESCRIPTION
Fix attribution for RT#45160. See https://rt.cpan.org/Ticket/Display.html?id=45160
