### PR TITLE
Only use FileSpec if on Windows platform

### DIFF
--- a/t/wperl.t
+++ b/t/wperl.t
@@ -1,11 +1,12 @@
 use strict;
 use IO::File;
 use File::Temp 0.16 ();
-use File::Spec 3.27;
 use Test::More;
 
 if ( $^O ne 'MSWin32' ) {
     plan skip_all => "not MSWin32";
+} else {
+    eval "use File::Spec 3.27;"; die $@ if $@;
 }
 
 ( my $wperl = $^X ) =~ s/perl\.exe$/wperl.exe/i;


### PR DESCRIPTION
In IO-CaptureOutput 1.1103, a change was made in wperl.t to require File::Spec 3.27. This change breaks the build process in Linux distributions which include an older version of File::Spec (for example, SUSE Linux Enterprise 11 includes version 3.2501).

As this is a Windows specific test, the 'use File::Spec 3.27' requirement can be moved behind an eval statement after the Windows platform check This allows the build process to work on Linux (without the File::Spec requirement), while still ensuring File::Spec 3.27 is required for Windows platforms.