### PR TITLE
Mark distribution as deprecated

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,3 +12,5 @@ remove = Win32
 
 [OSPrereqs / MSWin32]
 File::Spec = 3.27
+
+[Deprecated]

--- a/lib/IO/CaptureOutput.pm
+++ b/lib/IO/CaptureOutput.pm
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 package IO::CaptureOutput;
-# ABSTRACT: capture STDOUT and STDERR from Perl code, subprocesses or XS
+# ABSTRACT: (DEPRECATED) capture STDOUT and STDERR from Perl code, subprocesses or XS
 
 our $VERSION = '1.1105';
 


### PR DESCRIPTION
This patch updates the distribution's metadata to reflect the fact that it's been deprecated in favour of Capture::Tiny.

See http://neilb.org/2015/01/17/deprecated-metadata.html for more details.
